### PR TITLE
Avoid loosing event handlers and reactivity

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,8 @@ module.exports = async function (
     quality = 0.92,
     download = true,
     ignore = null,
-    cssinline = 1
+    cssinline = 1,
+    background = null
   } = {}
 ) {
   // Accept a selector or directly a DOM Element
@@ -75,6 +76,10 @@ module.exports = async function (
   // of the source element
   if (cssinline === 1) {
     inlineStyles(source, target);
+  }
+
+  if (background) {
+    target.style.background = background
   }
 
   //Remove unwanted elements

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ d3ToPng('selector', 'name');
 
 ## Mandatory fields
 
-- **Selector** (String): Commonly 'svg'.
+- **Selector** (String): Commonly 'svg' or DOM Element.
 - **Name** (String): Name for the file output, without extension.
 
 Output: **name.png**

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,8 @@ d3ToPng('svg', 'name', {
   format: 'webp',
   quality: 0.01,
   download: false,
-  ignore: '.ignored'
+  ignore: '.ignored',
+  background: 'white'
 }).then(fileData => {
   //do something with the data
 });
@@ -43,6 +44,7 @@ d3ToPng('svg', 'name', {
 - **quality** (number): Between 0 (lowest) and 1. Affects formats with compression, like jpg. Default: _.92_
 - **download** (boolean): Whether to download the resulting image. Default: _true_
 - **ignore** (string): A CSS selector that, the matched elements of which will not be added to the output. Default: _null_
+- **background** (string): A style to be added to the svg element. The value will be added as the _background_ shorthand css property, so it can be a single color, an image a gradient or any thing that is a valid background. Default: _null_
 
 ## Notes
 


### PR DESCRIPTION
Hi, I got an issue where the events attached to the svg element got lost when downloading it as png. There was also an issue with the framework that I use (vue.js) that add properties to the DOM elements. Events and thoses additional properties are not present in the innerHTML that was used to remember the original svg element.

To avoid loosing the events and additional properties, I change the way the svg element is handled. Instead of inlining the styles directly in the source svg and then restoring it as it was before, I make a copy of the svg in a detached element, and copy the applied styles from the source to the target. After that I remove ignored element. This way, I avoid changing the source svg and don't need to restore it.

A few other bugs are fixed in the pull request:
- remove the <a> element that is added to the DOM to download the image after triggering the click
- fix and improve the canvas.toDataURL part

I know there is quite a lot of change in a single commit. Feel free to just reject it, merge it directly or take just part of it.

By the way, this may also fix #12.

I also fix #11 in the last commit, this was an easy one.