### PR TITLE
Fix export for Firefox

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,9 +12,12 @@ function inlineStyles (source, target) {
 }
 
 function copyToCanvas ({ source, target, scale, format, quality }) {
+  let svgSize = source.getBoundingClientRect();
+  target.setAttribute('width', svgSize.width + 'px');
+  target.setAttribute('height', svgSize.height + 'px');
+
   let svgData = new XMLSerializer().serializeToString(target);
   let canvas = document.createElement('canvas');
-  let svgSize = source.getBoundingClientRect();
 
   //Resize can break shadows
   canvas.width = svgSize.width * scale;


### PR DESCRIPTION
Firefox can only draw SVGs with absolute dimensions, otherwise an empty PNG is returned.
https://bugzilla.mozilla.org/show_bug.cgi?id=700533